### PR TITLE
Use jitpack for deployment and the bukkit-plugin because repo.dustplanet.de is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Add the following repo to your `pom.xml`:
 ```xml
     <repositories>
         <repository>
-            <id>dustplanet-releases</id>
-            <url>https://repo.dustplanet.de/artifactory/libs-release-local</url>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 
    <dependencies>
         <dependency>
-            <groupId>net.gravitydevelopment.updater</groupId>
+            <groupId>com.github.timbru31</groupId>
             <artifactId>updater</artifactId>
-            <version>4.0.0</version>
+            <version>updater-4.0.0</version> <!-- Or other releases -->
         </dependency>
     </dependencies>
 ```
@@ -40,16 +40,16 @@ Add the following repo to your `pom.xml`:
 ```xml
     <repositories>
         <repository>
-            <id>dustplanet-snapshots</id>
-            <url>https://repo.dustplanet.de/artifactory/libs-snapshot-local/</url>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 
    <dependencies>
         <dependency>
-            <groupId>net.gravitydevelopment.updater</groupId>
+            <groupId>com.github.timbru31</groupId>
             <artifactId>updater</artifactId>
-            <version>4.0.1-SNAPSHOT</version>
+            <version>master-SNAPSHOT</version>
         </dependency>
     </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>de.dustplanet</groupId>
-    <artifactId>bukkit-plugin</artifactId>
-    <version>5.5.0</version>
+    <groupId>com.github.timbru31</groupId>
+    <artifactId>bukkit-plugin-parent-pom</artifactId>
+    <version>bukkit-plugin-5.5.1</version>
     <relativePath />
   </parent>
 
@@ -33,6 +33,10 @@
     <repository>
       <id>parent</id>
       <url>https://repo.dustplanet.de/artifactory/bukkit-plugins/</url>
+    </repository>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Fixes #28 
You can see [here](https://jitpack.io/com/github/SimonIT/updater/master-updater-4.0.0-gb72acca-6/build.log) that the jitpack build works.